### PR TITLE
✨ docs: add SFTP guide and secure .env encryption doc

### DIFF
--- a/docs/development/secured_env.md
+++ b/docs/development/secured_env.md
@@ -1,0 +1,88 @@
+# Right Way to Store .env in Git
+
+## Table of Contents
+
+- [Right Way to Store .env in Git](#right-way-to-store-env-in-git)
+  - [Table of Contents](#table-of-contents)
+  - [Encrypting .env File](#encrypting-env-file)
+    - [Install OpenSSL](#install-openssl)
+    - [Decrypt Current .env](#decrypt-current-env)
+    - [Encrypt Current .env](#encrypt-current-env)
+    - [OpenSSL Password Save Note](#openssl-password-save-note)
+
+> You can notice that the .env file is listed in the .gitignore file. This is because storing sensitive information such as API keys, server host name and database credentials in your Git repository is a security risk.
+>
+> But from a convenience point of view, it would be convenient to move the .env file. But how do we do that? We use encryption, of course!
+
+Follow these steps for a secure backup of your .env file into Git.
+
+## Encrypting .env File
+
+### Install OpenSSL
+
+- For Windows:
+
+  [Follow these instructions](http://certificate.fyicenter.com/1966_Download_and_Install_OpenSSL_slproweb_Binary_for_Windows.html).
+
+  Launch the OpenSSL shell before proceeding.
+
+- For Ubuntu:
+
+  ```bash
+  sudo apt install openssl
+  ```
+
+### Decrypt Current .env
+
+> cd to root folder of git repo before.
+
+Run the following command, replacing USER with your username:
+
+```bash
+openssl enc -d -aes-256-cbc -salt -pbkdf2 -in .env.crypt/.env.USER -out .env
+```
+
+For REST extension .env:
+
+```bash
+openssl enc -d -aes-256-cbc -salt -pbkdf2 -in .env.crypt/rest/.env.USER -out  rest/.env
+```
+
+Enter your password when prompted (avoid using -k key to prevent saving the password in .bash_history).
+
+### Encrypt Current .env
+
+> cd to root folder of git repo before.
+
+Create folder:
+
+```bash
+mkdir .env.crypt
+```
+
+Run the following command, replacing USER with your username:
+
+```bash
+openssl enc -aes-256-cbc -salt -pbkdf2 -in .env -out .env.crypt/.env.USER
+```
+
+When prompted, type a strong password. Remember, this password will be needed to decrypt the file later (avoid using -k key to prevent saving the password in .bash_history).
+
+### OpenSSL Password Save Note
+
+> As mentioned above, storing the password used to encrypt your .env file is crucial for later decryption. It is highly recommended to never store this password within the .env file itself or in plain text, telegram message, etc anywhere.
+>
+> For added security, I recommend using a password manager like _Bitwarden_ and creating a secure note for the password. This ensures that your password is encrypted and protected, further minimizing the risk of unauthorized access.
+
+Here's how to create a secure note in _Bitwarden_:
+
+- Log in to your _Bitwarden_ vault.
+- Click the "Add Item" button.
+- In the "Item Type" dropdown menu, select "Secure Note".
+- Enter a name for your note, such as **"Encrypted .env Password For ..."**.
+
+  In the "Note" field, paste your .env file encryption password.
+
+- Click the "Save" button.
+
+By following these steps, you can ensure that your .env file password is stored securely and conveniently within your _Bitwarden_ vault, alongside your other sensitive information.

--- a/docs/development/sftp.md
+++ b/docs/development/sftp.md
@@ -1,0 +1,50 @@
+# Configurating SFTP
+
+## Table of Contents
+
+- [Configurating SFTP](#configurating-sftp)
+  - [Table of Contents](#table-of-contents)
+  - [Steps](#steps)
+    - [0. Installing Extension](#0-installing-extension)
+    - [1. Create Enviroment File](#1-create-enviroment-file)
+    - [2. Securing Enviroment File](#2-securing-enviroment-file)
+    - [3. Ownering Files](#3-ownering-files)
+
+## Steps
+
+> 📝 Yes, you can use `scp`, `FileZilla` or any other solution you wish to deploy files to the debug server, but I strongly recommend using extention instead.
+
+### 0. Installing Extension
+
+Install [this](https://marketplace.visualstudio.com/items?itemName=satiromarra.code-sftp) extension and remove all another forks.
+
+> ⚠️ If you still want to use old extention by `liximomo` or `natizyskunk`, you can't use .env files, use [assume-unchanged](../README.md#preventing-leaking-passwords) mechanism for `.sftp` file.
+>
+> 📝 If you use any microsoft synchronization extension, look for documentation yourself on how to make it work and not save passwords in the repository
+
+### 1. Create Enviroment File
+
+> 📝 Make Sure Enviroment File Do Not Sync
+
+Create enviroment file `.env` (in root of project) with content like this:
+
+```INI
+SERVER1_HOST="xxx.yyy"
+SERVER1_USER="root"
+SERVER1_PASS="xxx"
+SERVER2_HOST="xxx.yyy"
+SERVER2_USER="root"
+SERVER2_PASS="xxx"
+```
+
+### 2. Securing Enviroment File
+
+Read this [file](/docs/development/secured_env.md) for more info.
+
+### 3. Ownering Files
+
+If `chmod` and/or `chown` not work as excepted, use `setfacl` instead:
+
+```Bash
+setfacl -R -m u:username:rwx /path/to/your/folder
+```


### PR DESCRIPTION
Add detailed documentation for securely storing and using .env files and for
configuring SFTP deployment in the development docs.

- docs/development/secured_env.md: add step-by-step guide on encrypting
  .env using OpenSSL (install instructions for Windows and Ubuntu,
  decrypt/encrypt commands with aes-256-cbc and pbkdf2, and notes to avoid
  using -k to prevent password leakage). Include guidance on storing the
  encryption password securely (recommend Bitwarden with secure note steps).
- docs/development/sftp.md: add an SFTP configuration guide (extension
  recommendation, caveats for older extensions, preventing .env sync,
  example .env template, and file ownership workaround using setfacl).

This improves developer security and onboarding by documenting a safe
workflow for backing up environment files in Git and a recommended SFTP
deployment setup.