### PR TITLE
✨ feat(ui): add lead list page and shared head/scripts

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -1,0 +1,26 @@
+<?php
+
+define("DIR", __DIR__);
+ini_set("default_socket_timeout", 29);
+
+require_once(DIR . "/api_v1/utilites.php");
+
+$url = parse_url($_SERVER["REQUEST_URI"]);
+parse_str($url["query"] ?? "", $query);
+
+
+$page = trim($url["path"], "/");
+
+switch ($page) {
+    case "":
+    case "add_lead":
+        include(DIR . "/templates/add_lead.php");
+        break;
+    case "get_lead":
+        include(DIR . "/templates/get_lead.php");
+        break;
+    default:
+        http_response_code(404);
+        include(DIR . "/templates/404.php");
+        break;
+}

--- a/www/subtemplates/head.php
+++ b/www/subtemplates/head.php
@@ -1,0 +1,22 @@
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>
+    body {
+        /* Prevent flashing of background color when loaded dark theme */
+        /* When styles are loaded, color will change automatically */
+        /* Head parsed before page start render */
+        background-color: #1f1f1f;
+    }
+</style>
+<link href=" https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+    integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link
+    href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap"
+    rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+
+<link rel="shortcut icon" type="image/png" href="res/img/fav/favicon.ico">
+
+<link rel="stylesheet" href="res/css/toast.css">

--- a/www/subtemplates/scripts.php
+++ b/www/subtemplates/scripts.php
@@ -1,0 +1,7 @@
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous">
+</script>
+
+<script src="res/js/toast.js"></script>
+<script src="res/js/main.js"></script>
+<script src="res/js/i18n.js"></script>

--- a/www/templates/404.php
+++ b/www/templates/404.php
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+    <title tr="404_title"></title>
+    <?php include_once("subtemplates/head.php"); ?>
+</head>
+
+<body>
+    <div class="container d-flex justify-content-center align-items-center vh-100">
+        <div class="card text-center shadow-lg">
+            <div class="card-header">
+                <h1 tr="404_title" class="card-title mb-0"></h1>
+            </div>
+            <div class="card-body">
+                <p tr="404_description" class="card-text"></p>
+                <a href="/" class="btn btn-primary w-100" tr="404_back">&nbsp;</a>
+            </div>
+
+        </div>
+    </div>
+    <div id="toaster"></div>
+    <?php include_once("subtemplates/scripts.php"); ?>
+</body>
+
+</html>

--- a/www/templates/add_lead.php
+++ b/www/templates/add_lead.php
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+    <title tr="add_lead_title"></title>
+    <?php include_once("subtemplates/head.php"); ?>
+</head>
+
+<body>
+    <nav class="navbar navbar-expand-sm bg-body-tertiary">
+        <div class="container-fluid">
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav">
+                    <li class="nav-item">
+                        <a class="nav-link active" aria-current="page" href="/add_lead" tr="add_lead"></a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" aria-current="page" href="/get_lead" tr="lead_list"></a>
+                    </li>
+
+                </ul>
+            </div>
+        </div>
+    </nav>
+    <div class="container mt-4">
+        <div class="row justify-content-center">
+            <div class="col-12 col-md-6 col-xl-4">
+                <div class="card text-center shadow-lg">
+                    <div class="card-header">
+                        <h1 class="mb-0" tr="add_lead" class="card-title"></h1>
+                    </div>
+                    <div class="card-body">
+                        <form id="add_lead_form">
+                            <div class="form-floating mb-3">
+                                <input type="text" placeholder="" required class="form-control" id="firstName">
+                                <label for="firstName" tr="add_lead_first_name"></label>
+                            </div>
+                            <div class="form-floating mb-3">
+                                <input type="text" placeholder="" required class="form-control" id="lastName">
+                                <label for="lastName" tr="add_lead_last_name"></label>
+                            </div>
+                            <div class="form-floating mb-3">
+                                <input type="tel" placeholder="" required class="form-control" id="phone">
+                                <label for="phone" tr="add_lead_phone"></label>
+                            </div>
+                            <div class="form-floating mb-4">
+                                <input type="email" placeholder="" required class="form-control" id="email">
+                                <label for="email" tr="add_lead_email"></label>
+                            </div>
+                            <button id="add_lead" tr="submit" class="btn btn-primary w-100"></button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="toaster"></div>
+    <?php include_once("subtemplates/scripts.php"); ?>
+</body>
+
+</html>

--- a/www/templates/get_lead.php
+++ b/www/templates/get_lead.php
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+    <title tr="add_lead_title"></title>
+    <?php include_once("subtemplates/head.php"); ?>
+</head>
+
+<body>
+    <nav class="navbar navbar-expand-sm bg-body-tertiary">
+        <div class="container-fluid">
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav">
+                    <li class="nav-item">
+                        <a class="nav-link" aria-current="page" href="/add_lead" tr="add_lead"></a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link active" aria-current="page" href="/get_lead" tr="lead_list"></a>
+                    </li>
+
+                </ul>
+            </div>
+        </div>
+    </nav>
+    <div class="container mt-4">
+        <div class="card text-center shadow-lg">
+            <div class="card-header">
+                <h1 tr="statuses" class="card-title mb-0"></h1>
+            </div>
+            <div class="card-body">
+                <div class="row g-2">
+                    <div class="col-md-5">
+                        <label tr="date_from_label" for="date_from" class="form-label"></label>
+                        <input type="datetime-local" id="date_from" class="form-control" value="2022-12-01T00:00:00">
+                    </div>
+                    <div class="col-md-5">
+                        <label tr="date_to_label" for="date_to" class="form-label"></label>
+                        <input type="datetime-local" id="date_to" class="form-control" value="2022-12-31T23:59:59">
+                    </div>
+                    <div class="col-md-2">
+                        <label tr="page_label" for="page" class="form-label"></label>
+                        <input type="number" id="page" name="page" class="form-control" value="1" min="1">
+                    </div>
+                    <div class="col-md-12">
+                        <button id="get_lead" tr="receive" class="btn btn-primary w-100 mt-3"></button>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+        <div class="card text-center shadow-lg mt-4 d-none" id="tableCard">
+            <div class="card-header">
+                <h1 tr="result" class="card-title mb-0"></h1>
+            </div>
+            <div class="card-body">
+                <div class="table-container overflow-auto" style="max-height: 360px;">
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th scope="col" tr="t_id"></th>
+                                <th scope="col" tr="t_email"></th>
+                                <th scope="col" tr="t_status"></th>
+                                <th scope="col" tr="t_ftd"></th>
+                            </tr>
+                        </thead>
+                        <tbody id="responseTable">
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+        <div id="toaster"></div>
+        <?php include_once("subtemplates/scripts.php"); ?>
+</body>
+
+</html>


### PR DESCRIPTION
- Add new get_lead.php view to render a lead query UI and results table.
  - a Bootstrap-based form for date range, page number and a fetch button.
  - Includes a responsive table container to show returned leads and a toaster container for notifications.
  - Markup uses translation attributes (tr=...) for i18n keys.

- Add subtemplates/head.php to centralize head elements and assets.
  - Include meta tags, initial dark background style to avoid flash, Google Fonts, Bootstrap CSS and icons.
  - Prepares common head for pages to ensure consistent styling.

- Add subtemplates/scripts.php to load Bootstrap JS and app scripts.
  - Loads bootstrap.bundle from CDN and app JS files (toast, main, i18n).